### PR TITLE
Do not pass key events to the drop_list.

### DIFF
--- a/qDict/src/main/java/com/annie/dictionary/MainActivity.kt
+++ b/qDict/src/main/java/com/annie/dictionary/MainActivity.kt
@@ -596,10 +596,6 @@ class MainActivity : BaseActivity(), NavigatorFragment.NavigationCallbacks, OnCl
         }
 
         override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-            if (keyCode != KeyEvent.KEYCODE_SPACE && (drop_list.selectedItemPosition >= 0 || keyCode != KeyEvent.KEYCODE_SEARCH && keyCode != KeyEvent.KEYCODE_DPAD_CENTER)) {
-                drop_list.onKeyUp(keyCode, event)
-            }
-
             when (keyCode) {
                 // avoid passing the focus from the text view to the next
                 // component
@@ -609,10 +605,6 @@ class MainActivity : BaseActivity(), NavigatorFragment.NavigationCallbacks, OnCl
         }
 
         override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-            if (keyCode != KeyEvent.KEYCODE_SPACE && (drop_list.selectedItemPosition >= 0 || keyCode != KeyEvent.KEYCODE_SEARCH && keyCode != KeyEvent.KEYCODE_DPAD_CENTER)) {
-                drop_list.requestFocusFromTouch()
-                drop_list.onKeyDown(keyCode, event)
-            }
             when (keyCode) {
                 // avoid passing the focus from the text view to the next
                 // component


### PR DESCRIPTION
This causes the EditText to lose focus while typing, especially on devices with a hardware keyboard.

-------------
PR comments:

This change made it possible for me to use QDict on a device with a hardware keyboard :)

More precisely: on a device with a hardware keyboard every key press would result in the text field losing focus and the first item of the drop_list. A workaround was to use the virtual keyboard. However, the issue sometimes also occurred when using the virtual keyboard.

To be honest, I don't understand the purpose of passing they key events to the `drop_list`. It seems impossible to select any item from the drop_list while typing in the EditText, so it doesn't make much sense to check for `drop_list.selectedItemPosition.`

Moreover, the whole condition from the `if` will usually evaluate to `true` for any key, regardless of the drop list state. Perhaps you meant `&&` instead of `||`, but I still don't get your intention.